### PR TITLE
fix pin_file_to_ipfs

### DIFF
--- a/pinatapy/__init__.py
+++ b/pinatapy/__init__.py
@@ -81,7 +81,7 @@ class PinataPy:
         url_suffix = "pinning/pinFileToIPFS"
         if type(path_to_file) is str: path_to_file = Path(path_to_file)
         if path_to_file.is_dir():
-            files = [("file",(str(file), open(file, "rb"))) for file in path_to_file.glob('**/*') if not file.is_dir()]
+            files = [("file",(file.as_posix(), open(file, "rb"))) for file in path_to_file.glob('**/*') if not file.is_dir()]
         else:
             files = {
                     "file": open(path_to_file, "rb")


### PR DESCRIPTION
 str(file) returns "foldername\\folder"  on windows.
This is because i quote the python docs "The string representation of a path is the raw filesystem path itself (in native form, e.g. with backslashes under Windows)"
It should be changed to  file.as_posix() which returns "foldername/folder" independently of platform