### PR TITLE
Fix pin file endpoint

### DIFF
--- a/pinatapy/__init__.py
+++ b/pinatapy/__init__.py
@@ -36,7 +36,7 @@ class PinataPy:
 
         More: https://docs.pinata.cloud/api-pinning/pin-file
         """
-        url: str = API_ENDPOINT + "pinning/addHashToPinQueue"
+        url: str = API_ENDPOINT + "pinning/pinFileToIPFS"
         headers: Headers = self._auth_headers
 
         def get_all_files(directory: str) -> tp.List[str]:

--- a/pinatapy/__init__.py
+++ b/pinatapy/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Non-official Python library for Pinata.cloud"""
 
 import os


### PR DESCRIPTION
This small PR contains two updates:
1. It fixes Pinata.cloud pin file endpoint,
2. It removes source code encoding specification while UTF-8 is [default](https://docs.python.org/3.5/tutorial/interpreter.html#source-code-encoding) for newer Python versions.