### PR TITLE
Add ability to define IPFS destination folder in Pinata's Cloud Manager for 'pin_file_to_ipfs()'

### DIFF
--- a/pinatapy/__init__.py
+++ b/pinatapy/__init__.py
@@ -30,7 +30,10 @@ class PinataPy:
 
     @staticmethod
     def _validate_destination_folder_name(path: str) -> str:
-        """Validates the IPFS destination folder name is valid"""
+        """
+        Validates the IPFS destination folder name is valid by removing 
+        blankspaces and adding '/' to the end of the path
+        """
         path = path.replace(" ", "")
         if not path.endswith("/"):
             path = path + "/"
@@ -45,7 +48,21 @@ class PinataPy:
         """
         Pin any file, or directory, to Pinata's IPFS nodes
 
-        More: https://docs.pinata.cloud/api-pinning/pin-file
+        Args:
+            path_to_file: local path of file/directory to upload to IPFS node
+            ipfs_destination_path: destination path of file(s) on the IPFS node. 
+                You can only set one destination path per call. 
+                Pathway can be viewed in the Pinata Cloud Pin Manager (https://app.pinata.cloud/pinmanager).
+                Ex: input => destination path
+                    '' => /
+                    'animal-nfts/' => /animal-nfts/
+                    'retro-nfts/animals' => /retro-nfts/animals/
+            options: optional parameters (pinataMetadata, pinataOptions)
+
+        Returns:
+            JSON response
+
+        More: https://docs.pinata.cloud/pinata-api/pinning/pin-file-or-directory
         """
         url: str = API_ENDPOINT + "pinning/pinFileToIPFS"
         headers: Headers = { k: self._auth_headers[k] for k in ["pinata_api_key", "pinata_secret_api_key"] }
@@ -65,9 +82,11 @@ class PinataPy:
 
         files: tp.List[str, tp.Any]
 
+        # If path_to_file is a directory
         if os.path.isdir(path_to_file):
             all_files: tp.List[str] = get_all_files(path_to_file)
             files = [("file", (dest_folder_name + file.split("/")[-1], open(file, "rb"))) for file in all_files]
+        # If path_to_file is a single file
         else:
             files = [("file", (dest_folder_name + path_to_file.split("/")[-1], open(path_to_file, "rb")))]
 
@@ -97,7 +116,7 @@ class PinataPy:
         """
         Pin file to Pinata using its IPFS hash
 
-        https://docs.pinata.cloud/api-pinning/pin-by-hash
+        https://docs.pinata.cloud/pinata-api/pinning/pin-by-cid
         """
         payload: OptionsDict = {"pinataMetadata": {"name": filename}, "hashToPin": ipfs_hash}
         url: str = API_ENDPOINT + "/pinning/pinByHash"
@@ -108,7 +127,7 @@ class PinataPy:
         """
         Retrieves a list of all the pins that are currently in the pin queue for your user.
 
-        More: https://docs.pinata.cloud/api-pinning/pin-jobs
+        More: https://docs.pinata.cloud/pinata-api/pinning/list-pin-by-cid-jobs
         """
         url: str = API_ENDPOINT + "pinning/pinJobs"
         payload: OptionsDict = options if options else {}
@@ -116,7 +135,11 @@ class PinataPy:
         return response.json() if response.ok else self._error(response)  # type: ignore
 
     def pin_json_to_ipfs(self, json_to_pin: tp.Any, options: tp.Optional[OptionsDict] = None) -> ResponsePayload:
-        """pin provided JSON"""
+        """
+        pin provided JSON
+        
+        More: https://docs.pinata.cloud/pinata-api/pinning/pin-json
+        """
         url: str = API_ENDPOINT + "pinning/pinJSONToIPFS"
         headers: Headers = self._auth_headers
         headers["Content-Type"] = "application/json"


### PR DESCRIPTION
Add new parameter called `ipfs_destination_path` to `pin_file_to_ipfs()`. This new parameter allows the user to set the destination folder name on IPFS in Pinata's Cloud Manager to better manage their uploads. This optional parameter defaults to uploading the files to the main Pinata directory. 

(I believe this PR resolves Issue https://github.com/Vourhey/pinatapy/issues/11.)

In these examples, we are uploading two PNG files.

**Example 1:**
```python
pin_file_to_ipfs(IMAGE_FOLDER_PATHWAY, ipfs_destination_path="my-new-nfts")
```
In Pinata's Cloud Manager UI, the <IpfsHash_01> will display the text "my-new-nfts".
Results:
`https://gateway.pinata.cloud/ipfs/<IpfsHash_01>/nft1.png`
`https://gateway.pinata.cloud/ipfs/<IpfsHash_01>/nft2.png`

**Example 2:**
```python
pin_file_to_ipfs(IMAGE_FOLDER_PATHWAY)
```
Results:
`https://gateway.pinata.cloud/ipfs/<IpfsHash_01>`
`https://gateway.pinata.cloud/ipfs/<IpfsHash_02>`
