### PR TITLE
Compatibility with code that uses v0.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pinatapy-vourhey",
-    version="0.1.5",
+    version="0.1.6",
     author="Vadim Manaenko",
     author_email="vadim.razorq@gmail.com",
     description="Non-official Pinata.cloud library",


### PR DESCRIPTION
After updates were made a week ago, the behavior of the pin_file_to_ipfs() function was changed. It used absolute paths for files but the new version started cutting file paths using only filenames. 


I added a param to use both file path rules and set a default value to make old projects compatible with a new version.
